### PR TITLE
fix setup.sh script to take build_linux_internal option

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -78,6 +78,9 @@ while [[ "$#" -gt 0 ]]; do
                 --run-jupyter)
                         FUNC=run_jupyter
                         ;;
+                build_linux_internal)
+                        FUNC=build_linux_internal
+                        ;;
                 *)
                         echo "Unknown parameter passed: $1"; exit 1 ;;
         esac


### PR DESCRIPTION
Currently, you get the following error while trying to build the linux kernel with the --build-linux option.

./setup.sh --build-linux
build_linux
Unknown parameter passed: build_linux_internal

Fix this by adding the function build_linux_internal to handle internal function handoff in the parser loop.